### PR TITLE
Fix Makefile and its documentation

### DIFF
--- a/k8s/openstad/Makefile
+++ b/k8s/openstad/Makefile
@@ -1,19 +1,20 @@
 chart-name=openstad
+namespace=openstad
 
 debug: clean
 	@echo "Creating a dry-run log..."
 	@mkdir -p debug
 	@helm install $(chart-name) . --dry-run --debug > debug/dry-run-debug-log.txt
-	@echo "Dry-run log created successfuly!"
+	@echo "Dry-run log created successfully!"
 
 install-dependencies:
 	helm dependency update
 
 install: install-dependencies
-	helm install $(chart-name) . -n openstad --create-namespace
+	helm install $(chart-name) . -n $(namespace) --create-namespace
 
 upgrade: 
-	helm upgrade $(chart-name) .
+	helm upgrade $(chart-name) . -n $(namespace)
 
 test:
 	helm install openstad .
@@ -31,7 +32,7 @@ get-values:
 	@helm inspect values .
 
 uninstall:
-	helm uninstall $(chart-name) --keep-history
+	helm uninstall $(chart-name) -n $(namespace) --keep-history
 
 clean:
 	rm -rf ./debug

--- a/k8s/openstad/README.md
+++ b/k8s/openstad/README.md
@@ -5,7 +5,7 @@ This chart handles the deployemont of the OpenStad application.
 
 ## Makefile
 
-I use [make](Makefile) to make commands easier and faster for me to type. This isn't a requirement, you can also stick with `helm` commands.
+One can use [make](Makefile) to make commands easier and faster to type. This isn't a requirement, you can also stick with `helm` commands.
 
 ### Requirements
 
@@ -16,6 +16,8 @@ sudo apt-get install build-essentials
 ```
 
 ### Commands
+
+All these commands use [the `values.yaml` file](./values.yaml), and installation uses the `openstad` namespace.
 
 `make install-dependencies` install any required chart, run this before any other command
 


### PR DESCRIPTION
Minor fixes: the Makefile was using a namespace for `helm install`, but not for `helm uninstall` and `helm upgrade`. Also, it was using a hardcoded namespace, while the chart name was a variable.

I've not added the namespace to the `debug` and `test` recipes.