### PR TITLE
Add cookieMaxAge env value to frontend

### DIFF
--- a/k8s/openstad/templates/frontend/deployment.yaml
+++ b/k8s/openstad/templates/frontend/deployment.yaml
@@ -42,6 +42,8 @@ spec:
               value: 'ON'
             - name: GOOGLE_MAPS_API_KEY
               value: "{{ .Values.frontend.googleMapsApiKey }}"
+            - name: COOKIE_MAX_AGE
+              value: "{{ .Values.frontend.cookieMaxAge }}"
             - name: IMAGE_API_ACCESS_TOKEN
               valueFrom:
                 secretKeyRef:

--- a/k8s/openstad/values.yaml
+++ b/k8s/openstad/values.yaml
@@ -138,6 +138,8 @@ frontend:
 
   googleMapsApiKey:
 
+  cookieMaxAge:
+
   # Ingress settings:
   # Configure how the service is accessed
   ingress:


### PR DESCRIPTION
This variable makes the cookie express `maxAge` value of Apostrophe configurable.