### PR TITLE
Allow the default favicon to be set for the auth service

### DIFF
--- a/k8s/openstad/templates/auth/deployment.yaml
+++ b/k8s/openstad/templates/auth/deployment.yaml
@@ -152,6 +152,9 @@ spec:
           - name: FROM_EMAIL
             value: {{ .Values.secrets.mail.auth.user }}
 
+          - name: DEFAULT_FAVICON
+            value: {{ .Values.auth.defaultFavicon }}
+
           # KUBERNETES
           - name: KUBERNETES_NAMESPACE
             valueFrom:

--- a/k8s/openstad/values.yaml
+++ b/k8s/openstad/values.yaml
@@ -309,6 +309,8 @@ auth:
       initialDelaySeconds: 30
       periodSeconds: 60
 
+  defaultFavicon:
+
 
 ## Settings for the Admin server
 admin:


### PR DESCRIPTION
This adds support for this PR: https://github.com/Amsterdam/openstad-oauth2-server/pull/47