### PR TITLE
Set the correct APP_URL for the image-server deployment

### DIFF
--- a/k8s/openstad/templates/image/deployment.yaml
+++ b/k8s/openstad/templates/image/deployment.yaml
@@ -46,7 +46,7 @@ spec:
                 name: mysql-secret
                 key: mysql-password
           - name: APP_URL
-            value: www.{{ .Values.host.base }}
+            value: https://img.{{ .Values.host.base }}
           - name: FIRST_IMAGE_API_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:


### PR DESCRIPTION
The image-server `APP_URL` would have the URL of the base host. This works fine when this URL linked to an openstad-frontend site, but this is not applicable to every environment.
Another issue arises when there are multiple sites, the image server would still always return the URL of the base host, which is not an ideal situation.

This commit changes the image-server deployment to use the URL of the image server by default, which is https://img.BASEHOST