### PR TITLE
Set correct mount path for image server

### DIFF
--- a/k8s/openstad/templates/image/deployment.yaml
+++ b/k8s/openstad/templates/image/deployment.yaml
@@ -72,7 +72,7 @@ spec:
           initialDelaySeconds: {{ .Values.image.probe.liveness.initialDelaySeconds }}
           periodSeconds: {{ .Values.image.probe.liveness.periodSeconds }}
         volumeMounts:
-          - mountPath: /home/app/data
+          - mountPath: /app/images
             name: data-vol
       initContainers:
       - name: create-db-ready


### PR DESCRIPTION
Set the correct mountPath for the image server, so the data-vol persistent volume is mounted on `/app/images`.

When this is used on an existing cluster, an issue with ownership for the `/app/images` folder might arise. A possible fix for this has been added to `docs/troubleshooting.md`.

This PR fixes #56